### PR TITLE
Enable proxy support for the HTTP(S) request

### DIFF
--- a/check_json.pl
+++ b/check_json.pl
@@ -100,6 +100,7 @@ if ($np->opts->verbose) { (print Dumper ($np))};
 ## GET URL
 my $ua = LWP::UserAgent->new;
 
+$ua->env_proxy;
 $ua->agent('check_json/0.5');
 $ua->default_header('Accept' => 'application/json');
 $ua->protocols_allowed( [ 'http', 'https'] );


### PR DESCRIPTION
The 'env_proxy' option automatically loads proxy settings from *_proxy environment variables, if they are defined. This behaviour is consistent with other tools such as curl, wget, etc.